### PR TITLE
Allow embedding local images

### DIFF
--- a/pypub/chapter.py
+++ b/pypub/chapter.py
@@ -60,6 +60,12 @@ def save_image(image_url, image_directory, image_name):
     if image_type is None:
         raise ImageErrorException(image_url)
     full_image_file_name = os.path.join(image_directory, image_name + '.' + image_type)
+
+    # If the image is present on the local filesystem just copy it
+    if os.path.exists(image_url):
+        shutil.copy(image_url, full_image_file_name)
+        return image_type
+
     try:
         # urllib.urlretrieve(image_url, full_image_file_name)
         with open(full_image_file_name, 'wb') as f:


### PR DESCRIPTION
Currently, there is no way to use local images in epubs, even with `create_chapter_from_string`: pypub [tries to fetch the image from the network](https://github.com/wcember/pypub/blob/d05366a78cc17b223029fce94a4d194cc2af4fc6/pypub/chapter.py#L63-L74), and if the fetch fails [it removes the img tag](https://github.com/wcember/pypub/blob/d05366a78cc17b223029fce94a4d194cc2af4fc6/pypub/chapter.py#L105-L106). This prevents embedding local images, if the whole source of the ebook is in the local filesystem.

This pull request changes `save_image` to first check if it's present on the local filesystem, and only if it's not present it tries to fetch it from the network.